### PR TITLE
return correct http code when trying to create an existing user

### DIFF
--- a/backend/api/routes/users.py
+++ b/backend/api/routes/users.py
@@ -186,11 +186,11 @@ async def create_user(session: SessionDep, user: UserCreate):
     # check if username or email already exists
     user_exists = await get_user_by_username(user.username, session)
     if user_exists:
-        raise HTTPException(status_code=400, detail="Username already exists")
+        raise HTTPException(status_code=409, detail="Username already exists")
 
     user_exists = await get_user_by_email(user.email, session)
     if user_exists:
-        raise HTTPException(status_code=400, detail="Try another email address")
+        raise HTTPException(status_code=409, detail="Try another email address")
 
     # get basic role
     role = await get_role("visitor", session)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,7 +32,6 @@ numpy==2.0.1
 orjson==3.10.3
 pandas==2.2.2
 passlib==1.7.4
-psycopg2==2.9.9
 pyasn1==0.6.0
 pycparser==2.22
 pydantic==2.7.1


### PR DESCRIPTION
Initially when a post request was sent to create a user who already exists in the database, the API responds with 400 bad request error code.
However, the correct http code the api is supposed to respond with is a 409 conflict. I have fixed this