### PR TITLE
Fix: Replace psycopg2 IntegrityError with SQLAlchemy's for Render deployment

### DIFF
--- a/backend/db/permissions.py
+++ b/backend/db/permissions.py
@@ -1,6 +1,6 @@
 from typing import Literal, get_args
 
-from psycopg2 import IntegrityError
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import col, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 


### PR DESCRIPTION
This PR fixes deployment issues on Render by replacing psycopg2 IntegrityError import with SQLAlchemy's version. The change ensures compatibility with our async DB setup in production environments while maintaining functionality in development environments.